### PR TITLE
增加 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:alpine
+COPY . /go/src/app
+WORKDIR /go/src/app
+RUN go-wrapper download && go-wrapper install
+ENTRYPOINT ["go-wrapper", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine
-COPY . /go/src/app
-WORKDIR /go/src/app
-RUN go-wrapper download && go-wrapper install
-ENTRYPOINT ["go-wrapper", "run"]
+COPY . /go/src/upx
+WORKDIR /go/src/upx
+RUN go get -d -v && go install -v
+CMD ["upx"]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ go get github.com/polym/upx
 
 ```bash
 docker build -t upx .
-docker run --rm upx -v
+docker run --rm upx upx -v
 ```
 
 ## 使用

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ or
 $ go get github.com/polym/upx
 ```
 
+### Docker
+
+```bash
+docker build -t upx .
+docker run --rm upx -v
+```
+
 ## 使用
 
 > 所有命令都支持 `-h` 查看使用方法


### PR DESCRIPTION
本 PR 旨在增加 Dockerfile 方便构建 docker 镜像。

在 GitLab CI 等地方，有时需要上传产物到 upyun。此时，若有现成的 docker 镜像用于运行 upx，会极大的方便使用。

希望作者能接受 PR，并到 Docker Hub 上创建对应的 Automated Build。这样，用户也可以使用简单的两行命令在 Docker 中体验 UPX：

```bash
docker pull polym/upx
docker run --rm polym/upx upx --help
```